### PR TITLE
fix(ProjectView): pass object instead of array to the project state and refacto unused useEffect + unnecessary confusing naming

### DIFF
--- a/app/src/scenes/project/view.js
+++ b/app/src/scenes/project/view.js
@@ -17,22 +17,17 @@ ChartJS.register(...registerables);
 
 export default function ProjectView() {
   const [project, setProject] = useState(null);
-  const [copied, setCopied] = React.useState(false);
   const { id } = useParams();
   const history = useHistory();
 
   useEffect(() => {
     (async () => {
-      const { data: u } = await api.get(`/project/${id}`);
-      setProject(u);
+      const { data } = await api.get(`/project/${id}`);
+      setProject(data[0]);
     })();
   }, []);
 
-  useEffect(() => {
-    if (copied) {
-      setTimeout(() => setCopied(false), 3000);
-    }
-  }, [copied]);
+
 
   if (!project) return <Loader />;
 
@@ -60,7 +55,7 @@ export default function ProjectView() {
 }
 
 const ProjectDetails = ({ project }) => {
-  console.log(project);
+
   return (
     <div>
       <div className="flex flex-wrap p-3">


### PR DESCRIPTION
1. Fix the error shown on the page (`name.toString()` with name undefined): We recieve an array from the api call and pass it directly to the ProjectDetails componant. But the ProjectDetailsComponants needs an object so i changed the data sent to the project state to be an object instead of an array of one object.

2. Refactor data variable: The data from the api was renamed  "u" which is unnecessary and confusing so I set it back to "data"

3. Refactor unused useEffect(): A useEffect was written to add setTimeOut when the copied state is true but this state is never updated or used. I have deleted this dead code